### PR TITLE
fix(docs): remove duplicate Bun tab from templates page

### DIFF
--- a/docs/getting-started/templates.mdx
+++ b/docs/getting-started/templates.mdx
@@ -43,10 +43,6 @@ yarn dlx extension@latest create my-extension --template=<slug>
 bunx extension@latest create my-extension --template=<slug>
 ```
 
-```bash bun
-bunx extension@latest create my-extension --template=<slug>
-```
-
 </CodeGroup>
 
 Replace `<slug>` with the template you want to start from.

--- a/zh-Hans/docs/getting-started/templates.mdx
+++ b/zh-Hans/docs/getting-started/templates.mdx
@@ -43,10 +43,6 @@ yarn dlx extension@latest create my-extension --template=<slug>
 bunx extension@latest create my-extension --template=<slug>
 ```
 
-```bash bun
-bunx extension@latest create my-extension --template=<slug>
-```
-
 </CodeGroup>
 
 把 `<slug>` 替换为你想要的模板名。

--- a/zh-Hant/docs/getting-started/templates.mdx
+++ b/zh-Hant/docs/getting-started/templates.mdx
@@ -43,10 +43,6 @@ yarn dlx extension@latest create my-extension --template=<slug>
 bunx extension@latest create my-extension --template=<slug>
 ```
 
-```bash bun
-bunx extension@latest create my-extension --template=<slug>
-```
-
 </CodeGroup>
 
 將 `<slug>` 替換成你想要的範本名稱。


### PR DESCRIPTION
## Summary

Removes the duplicated `bun` code block from the Templates documentation page, which caused the `CodeGroup` component to render two **bun** tabs.

## Changes

* Removed the duplicate `bun` code block from:

  * `docs/getting-started/templates.mdx`
  * `zh-Hans/docs/getting-started/templates.mdx`
  * `zh-Hant/docs/getting-started/templates.mdx`

## Test plan

* [x] Automated tests updated or not needed
* [x] Manual testing completed
* [x] Docs updated or not needed

## Related links

* Issue: extension-js/extension.js#471
* Discussion: The issue was reported in the extension.js repository, while the fix belongs in the extension.js.org documentation repository. This PR implements the documentation change corresponding to that report.